### PR TITLE
feat: add progress steps component

### DIFF
--- a/src/components/ProgressSteps.tsx
+++ b/src/components/ProgressSteps.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+interface ProgressStepsProps {
+    step: number
+    total?: number
+}
+
+export default function ProgressSteps({ step, total = 3 }: ProgressStepsProps) {
+    const percentage = (step / total) * 100
+
+    return (
+        <div className='w-full my-4'>
+            <div className='flex justify-end mb-1'>
+                <span className='text-[13px] text-gray-700'>{step}/{total}</span>
+            </div>
+            <div className='w-full h-2 bg-[var(--white-bg)] rounded-full'>
+                <div
+                    className='h-full bg-[var(--pink-strong)] rounded-full transition-all duration-300'
+                    style={{ width: `${percentage}%` }}
+                ></div>
+            </div>
+        </div>
+    )
+}
+

--- a/src/pages/cadastre-se/index.tsx
+++ b/src/pages/cadastre-se/index.tsx
@@ -3,6 +3,7 @@ import Container from '@/components/Container'
 import React, { useState } from 'react'
 import logo from '../../../public/spotme_logo.png'
 import Button from '@/components/Button'
+import ProgressSteps from '@/components/ProgressSteps'
 import Image from 'next/image'
 import { GoHeart } from "react-icons/go"
 import { IoPeopleOutline, IoEye, IoEyeOff } from "react-icons/io5"
@@ -194,6 +195,7 @@ export default function Cadastre() {
                             </div>
 
                             {/* FORM STEPS */}
+                            <ProgressSteps step={step} />
                             <div className='mt-5'>
                                 {step === 1 && (
                                     <>


### PR DESCRIPTION
## Summary
- add `ProgressSteps` component to show current step in sign-up flow
- use `ProgressSteps` in registration page with current step state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68aea0d75e988328a99bd85e67c03327